### PR TITLE
Unset HTTP proxy env variables when running tests

### DIFF
--- a/t/13-command-au.t
+++ b/t/13-command-au.t
@@ -18,6 +18,8 @@ use Test::More tests => 4;
 
 use WWW::Mechanize::Shell;
 
+delete @ENV{qw(HTTP_PROXY http_proxy CGI_HTTP_PROXY)};
+
 my $server = Test::HTTP::LocalServer->spawn();
 
 my $user = 'foo';

--- a/t/18-browser-autosync.t
+++ b/t/18-browser-autosync.t
@@ -25,6 +25,8 @@ BEGIN {
 };
 use WWW::Mechanize::Shell;
 
+delete @ENV{qw(HTTP_PROXY http_proxy CGI_HTTP_PROXY)};
+
 my $browser_synced;
 { no warnings 'redefine';
   *WWW::Mechanize::Shell::sync_browser = sub {


### PR DESCRIPTION

In Debian we are currently applying the following patch to
WWW-Mechanize-Shell.
We thought you might be interested in it too.

    Description: Unset HTTP proxy env variables when running tests
     Some tests would fail when run in an environment that has HTTP proxy
     environment variables. For the tests that failed, we now unset the HTTP proxy
     variables.
    Author: Olivier Gayot <olivier.gayot@canonical.com>
    Bug-Ubuntu: https://launchpad.net/bugs/1953344
    Last-Update: 2021-12-06
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libwww-mechanize-shell-perl/raw/master/debian/patches/unset-http-proxy-for-tests

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
